### PR TITLE
Check files are the same before batch rename/trim

### DIFF
--- a/XCI Organizer/Form1.Designer.cs
+++ b/XCI Organizer/Form1.Designer.cs
@@ -842,7 +842,6 @@
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "XCI Organizer";
-            this.Activated += new System.EventHandler(this.Form1_Activated);
             this.contextMenuStrip1.ResumeLayout(false);
             this.TABC_Main.ResumeLayout(false);
             this.TABP_XCI.ResumeLayout(false);

--- a/XCI Organizer/Form1.cs
+++ b/XCI Organizer/Form1.cs
@@ -53,6 +53,7 @@ namespace XCI_Organizer {
         private BetterTreeNode rootNode;
         public List<char> chars = new List<char>();
         List<FileData> files = new List<FileData>();
+        string[] fileEntries;
         int sortByThis;
 
         private long[] SecureSize;
@@ -184,7 +185,7 @@ namespace XCI_Organizer {
                 LV_Files.Items.Clear();
 
                 string[] directories = Directory.GetDirectories(selectedPath);
-
+                fileEntries = Directory.GetFiles(selectedPath);
                 files = Util.GetXCIsInFolder(selectedPath);
 
                 if (!bwUpdateFileList.IsBusy) {
@@ -784,9 +785,21 @@ namespace XCI_Organizer {
             tt.Show("Options:\n%ID%\n%NAME%\n%PUBLISHER%\n%GROUP%\n%REGION%\n%LANGUAGES%\n%SERIAL%\n%TITLEID%\n%RELEASENAME%\n%FIRMWARE%", tb, 0, 20, VisibleTime);
         }
 
+        private bool IsGamesListUpToDate() {
+            string selectedPath = ini.IniReadValue("Config", "BaseFolder");
+            string[] currentFileEntries = Directory.GetFiles(selectedPath);
+            return String.Join(", ", fileEntries) == String.Join(", ", currentFileEntries);
+        }
+
         private void BT_BatchRename_Click(object sender, EventArgs e) {
             // Added back into main function because I was trying to debug it. Needs to be added into Util again
             string selectedPath = ini.IniReadValue("Config", "BaseFolder");
+            string[] currentFileEntries = Directory.GetFiles(selectedPath);
+
+            if (!IsGamesListUpToDate()) {
+                MessageBox.Show("Games directory has changed, please refresh and try again.", "XCI Organizer", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
 
             if (selectedPath.Trim() != "" && MessageBox.Show("Are you sure you want to rename ALL of your XCI files automatically?", "XCI Organizer", MessageBoxButtons.YesNo) == DialogResult.Yes) {
                 L_Status.Text = "Status: Batch renaming files...";
@@ -923,6 +936,11 @@ namespace XCI_Organizer {
         private void BT_BatchTrim_Click(object sender, EventArgs e) {
             // This should be safe now because it uses the same files list from UpdateFileList
             string selectedPath = ini.IniReadValue("Config", "BaseFolder");
+
+            if (!IsGamesListUpToDate()) {
+                MessageBox.Show("Games directory has changed, please refresh and try again.", "XCI Organizer", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
 
             if (selectedPath.Trim() != "" && MessageBox.Show("Are you sure you want to trim ALL of your XCI files automatically?\n", "XCI Organizer", MessageBoxButtons.YesNo) == DialogResult.Yes) {
                 L_Status.Text = "Status: Batch trimming...";
@@ -1235,16 +1253,6 @@ namespace XCI_Organizer {
             L_Status.Text = "Status: Removing old cache entries...";
             removeOldCacheEntries();
             L_Status.Text = "Status: Cache updated!";
-        }
-
-        void Form1_Activated(object sender, EventArgs e) {
-            // Temporary fix to make user refresh list due to potential files moved/renamed
-            if (!backgroundWorker1.IsBusy && !bwUpdateFileList.IsBusy && BT_BatchRename.Enabled) {
-                BT_BatchRename.Enabled = false;
-                BT_BatchTrim.Enabled = false;
-                BT_BatchRename.Text = "You must Refresh first!";
-                BT_BatchTrim.Text = "You must Refresh first!";
-            }
         }
 
         private void LV_Files_ColumnClick(object sender, ColumnClickEventArgs e) {

--- a/XCI Organizer/Form1.cs
+++ b/XCI Organizer/Form1.cs
@@ -185,7 +185,7 @@ namespace XCI_Organizer {
                 LV_Files.Items.Clear();
 
                 string[] directories = Directory.GetDirectories(selectedPath);
-                fileEntries = Directory.GetFiles(selectedPath);
+                fileEntries = Directory.GetFiles(selectedPath, "*.xci", SearchOption.AllDirectories);
                 files = Util.GetXCIsInFolder(selectedPath);
 
                 if (!bwUpdateFileList.IsBusy) {
@@ -787,14 +787,13 @@ namespace XCI_Organizer {
 
         private bool IsGamesListUpToDate() {
             string selectedPath = ini.IniReadValue("Config", "BaseFolder");
-            string[] currentFileEntries = Directory.GetFiles(selectedPath);
+            string[] currentFileEntries = Directory.GetFiles(selectedPath, "*.xci", SearchOption.AllDirectories);
             return String.Join(", ", fileEntries) == String.Join(", ", currentFileEntries);
         }
 
         private void BT_BatchRename_Click(object sender, EventArgs e) {
             // Added back into main function because I was trying to debug it. Needs to be added into Util again
             string selectedPath = ini.IniReadValue("Config", "BaseFolder");
-            string[] currentFileEntries = Directory.GetFiles(selectedPath);
 
             if (!IsGamesListUpToDate()) {
                 MessageBox.Show("Games directory has changed, please refresh and try again.", "XCI Organizer", MessageBoxButtons.OK, MessageBoxIcon.Warning);


### PR DESCRIPTION
This checks that the file list is still the same as when it was last refreshed before running the batch trim/rename functions.
If it is different, this message will appear:
![image](https://user-images.githubusercontent.com/7288322/42538961-9172bc06-84ed-11e8-9fc1-dad63d32539a.png)

*You might want to rename the `IsGamesListUpToDate` function, not really sure what it should be called.*