### PR TITLE
Revert batch trim speedup

### DIFF
--- a/XCI Organizer/Form1.cs
+++ b/XCI Organizer/Form1.cs
@@ -932,10 +932,20 @@ namespace XCI_Organizer {
             if (selectedPath.Trim() != "" && MessageBox.Show("Are you sure you want to trim ALL of your XCI files automatically?\n", "XCI Organizer", MessageBoxButtons.YesNo) == DialogResult.Yes) {
                 L_Status.Text = "Status: Batch trimming...";
                 buttonsEnabled(false);
+                int counter = 0;
+
+                //UpdateFileList();
+                //lboxFiles.SelectedIndex = counter;
+                LV_Files.Items[counter].Selected = true;
 
                 foreach (FileData file in files) {
-                    if (!file.ROMSize.Equals(file.UsedSpace) && File.Exists(file.FilePath)) {
+                    if (!TB_ROMExactSize.Text.Equals(TB_ExactUsedSpace.Text) && File.Exists(file.FilePath)) {
                         _TrimXCI();
+                    }
+
+                    if (++counter < files.Count) {
+                        LV_Files.Items[counter].Selected = true;
+                        //lboxFiles.SelectedIndex = counter;
                     }
                 }
                 // Info will be outdated if something is trimmed :/ Need better solution


### PR DESCRIPTION
Revert the speed up of batch trim function as it currently breaks it.
(batch rename still works fine)

`_TrimXCI()` relies on Global `selectedFile` and `UsedSize`.
Will make another PR later which removes the reliance on these globals (hopefully) and speeds it up again.